### PR TITLE
Fix NullPointerException in ExecuteAsyncOperationAdvice

### DIFF
--- a/instrumentation/src/main/java/kamon/instrumentation/mongo/ExecuteAsyncOperationAdvice.java
+++ b/instrumentation/src/main/java/kamon/instrumentation/mongo/ExecuteAsyncOperationAdvice.java
@@ -71,8 +71,10 @@ public class ExecuteAsyncOperationAdvice {
             }
 
             span.finish();
-          } else {
+          } else if (t != null) {
             span.fail(t).finish();
+          } else {
+            span.finish();
           }
         } finally {
           originalCallback.onResult(result, t);


### PR DESCRIPTION
There could be situation with both result == null and throwable == null at ExecuteAsyncOperationAdvice line 53. E.g. findOneAndReplace operation when it didn't find document to replace. In that case it  returns null as result and null as a throwable (there is no error).
